### PR TITLE
fix: allow for Symbolics > 6.34

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HarmonicBalance"
 uuid = "e13b9ff6-59c3-11ec-14b1-f3d2cc6c135e"
 authors = ["Orjan Ameye <orjan.ameye@hotmail.com>", "Jan Kosata <kosataj@phys.ethz.ch>", "Javier del Pino <jdelpino@phys.ethz.ch>"]
-version = "0.15.1"
+version = "0.15.2"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -28,11 +28,11 @@ HarmonicSteadyState = "0.2.1"
 JET = "0.9.18"
 ModelingToolkit = "9.60"
 PrecompileTools = "1.2"
-QuestBase = "0.3.0"
+QuestBase = "0.3.1"
 Random = "1.10"
 Reexport = "1.2.2"
 SymbolicUtils = "3.25"
-Symbolics = "~6.34.0"
+Symbolics = "6.34.0"
 Test = "1.10"
 julia = "1.10"
 


### PR DESCRIPTION
## Checklist

Thank you for contributing to `HarmonicBalance.jl`! Please make sure you have finished the following tasks before finishing the PR.


- [ ] Appropriate tests were added and tested locally by running: `make test`.
- [ ] Any code changes should be `julia` formatted by running: `make format`.
- [ ] All documents (in `docs/` folder) related to code changes were updated and able to build locally by running: `make docs`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description

 allow for Symbolics > 6.34 with QuestBase 0.3.1

## Related issues or PRs

supersedes #424 